### PR TITLE
Add support for dedicated nodefs-imagefs storage location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # provider-build-scripts
 
 First create the `/ephemeral` directory. It will be used for imagefs/nodefs.
+
 `mkdir -p /ephemeral`
+
 If the cluster has a dedicated nodefs/imagefs storage (a separate nvme drive or a number of drives in a RAID) make sure it's mounted on `/ephemeral`
 
 ## Example cluster installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # provider-build-scripts
 
+First create the `/ephemeral` directory. It will be used for imagefs/nodefs.
+`mkdir -p /ephemeral`
+If the cluster has a dedicated nodefs/imagefs storage (a separate nvme drive or a number of drives in a RAID) make sure it's mounted on `/ephemeral`
+
 ## Example cluster installation
 
 > `172.18.*` is the internal network

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 If the cluster has a dedicated ephemeral storage, specify the location using -o and -k
 Example
+```
 ./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18. -o /data/containerd -k /data/kubelet
+```
 
 ## Example cluster installation
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # provider-build-scripts
 
-First create the `/ephemeral` directory. It will be used for imagefs/nodefs.
-
-`mkdir -p /ephemeral`
-
-If the cluster has a dedicated nodefs/imagefs storage (a separate nvme drive or a number of drives in a RAID) make sure it's mounted on `/ephemeral`
+If the cluster has a dedicated ephemeral storage, specify the location using -o and -k
+Example
+./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18. -o /data/containerd -k /data/kubelet
 
 ## Example cluster installation
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ```
 
 If the cluster has a dedicated ephemeral storage, specify the location using -o and -k
+
 Example
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # provider-build-scripts
 
-If the cluster has a dedicated ephemeral storage, specify the location using -o and -k
-Example
-```
-./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18. -o /data/containerd -k /data/kubelet
-```
 
 ## Example cluster installation
 
@@ -17,6 +12,13 @@ Example
 
 ```
 ./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18.
+```
+
+If the cluster has a dedicated ephemeral storage, specify the location using -o and -k
+Example
+
+```
+./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18. -o /data/containerd -k /data/kubelet
 ```
 
 IMPORTANT: Note down the line `K3s control-plane and worker node token:` as it'll contain the token you'll need to join further nodes.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18.
 ```
 
-If the cluster has a dedicated ephemeral storage, specify the location using -o and -k
+If the cluster has a dedicated ephemeral storage, specify the location using -o and -k.
 
 Example
 
@@ -38,8 +38,24 @@ echo
 ./k3sAndProviderServices.sh -s provider.h100.sdg.val.akash.pub -e $(curl -s ident.me) -m 172.18.140.11 -c $TOKEN -g -n 172.18.
 ```
 
+If the cluster has a dedicated ephemeral storage, specify the location using -o and -k.
+
+Example
+
+```
+./k3sAndProviderServices.sh -s provider.h100.sdg.val.akash.pub -e $(curl -s ident.me) -m 172.18.140.11 -c $TOKEN -g -n 172.18. -o /data/containerd -k /data/kubelet
+```
+
 3. Join the worker nodes
 
 ```
 ./workerNode.sh -m 172.18.140.11 -t ${TOKEN} -g
+```
+
+If the cluster has a dedicated ephemeral storage, specify the location using -o and -k.
+
+Example
+
+```
+./workerNode.sh -m 172.18.140.11 -t ${TOKEN} -g -o /data/containerd -k /data/kubelet
 ```

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 1. Initialize the control-plane node
 
 > `provider.h100.sdg.val.akash.pub` is just the example  
-> `-e` - `curl -s ident.me` returns a public IP of the node  
 
 ```
-./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18.
+./k3sAndProviderServices.sh -d traefik -s provider.h100.sdg.val.akash.pub -g -n 172.18.
 ```
 
 If the cluster has a dedicated ephemeral storage, specify the location using -o and -k.
@@ -19,7 +18,7 @@ If the cluster has a dedicated ephemeral storage, specify the location using -o 
 Example
 
 ```
-./k3sAndProviderServices.sh -d traefik -e $(curl -s ident.me) -s provider.h100.sdg.val.akash.pub -g -n 172.18. -o /data/containerd -k /data/kubelet
+./k3sAndProviderServices.sh -d traefik -s provider.h100.sdg.val.akash.pub -g -n 172.18. -o /data/containerd -k /data/kubelet
 ```
 
 IMPORTANT: Note down the line `K3s control-plane and worker node token:` as it'll contain the token you'll need to join further nodes.
@@ -43,7 +42,7 @@ If the cluster has a dedicated ephemeral storage, specify the location using -o 
 Example
 
 ```
-./k3sAndProviderServices.sh -s provider.h100.sdg.val.akash.pub -e $(curl -s ident.me) -m 172.18.140.11 -c $TOKEN -g -n 172.18. -o /data/containerd -k /data/kubelet
+./k3sAndProviderServices.sh -s provider.h100.sdg.val.akash.pub -m 172.18.140.11 -c $TOKEN -g -n 172.18. -o /data/containerd -k /data/kubelet
 ```
 
 3. Join the worker nodes

--- a/k3sAndProviderServices.sh
+++ b/k3sAndProviderServices.sh
@@ -237,7 +237,7 @@ else
     fi
     # when K3S_URL is used, must add "server" when adding a new control-plane nodes to the cluster
     # it also must go first in the order, otherwise k3s.service will fail to start
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server ${k3s_common_args} ${install_exec}" K3S_URL="https://$master_ip:6443" K3S_TOKEN="$token" --data-dir /ephemeral sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server ${k3s_common_args} ${install_exec}" K3S_URL="https://$master_ip:6443" K3S_TOKEN="$token" sh -
     echo "Control-plane node added to the cluster."
 fi
 

--- a/k3sAndProviderServices.sh
+++ b/k3sAndProviderServices.sh
@@ -13,7 +13,7 @@ master_ip=""
 token=""
 internal_network=""
 tls_san="" # Example: provider.h100.sdg.val.akash.pub
-k3s_common_args="--disable=${disable_components} --flannel-backend=none"
+k3s_common_args="--disable=${disable_components} --flannel-backend=none  --kubelet-arg=root-dir=/ephemeral/kubelet"
 
 # Process command-line options
 while getopts ":d:e:tagm:c:r:w:n:s:" opt; do
@@ -174,7 +174,7 @@ if [[ "$mode" == "init" ]]; then
     if [[ -n "$tls_san" ]]; then
         install_exec+=" --tls-san=${tls_san}"
     fi
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="$k3s_common_args $install_exec" sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="$k3s_common_args $install_exec --data-dir /ephemeral" sh -
     echo "K3s installation completed."
     token=$(cat /var/lib/rancher/k3s/server/token)
     echo "K3s control-plane and worker node token: $token"
@@ -237,7 +237,7 @@ else
     fi
     # when K3S_URL is used, must add "server" when adding a new control-plane nodes to the cluster
     # it also must go first in the order, otherwise k3s.service will fail to start
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server ${k3s_common_args} ${install_exec}" K3S_URL="https://$master_ip:6443" K3S_TOKEN="$token" sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server ${k3s_common_args} ${install_exec}" K3S_URL="https://$master_ip:6443" K3S_TOKEN="$token" --data-dir /ephemeral sh -
     echo "Control-plane node added to the cluster."
 fi
 

--- a/k3sAndProviderServices.sh
+++ b/k3sAndProviderServices.sh
@@ -13,7 +13,7 @@ master_ip=""
 token=""
 internal_network=""
 tls_san="" # Example: provider.h100.sdg.val.akash.pub
-k3s_common_args="--disable=${disable_components} --flannel-backend=none  --kubelet-arg=root-dir=/ephemeral/kubelet"
+k3s_common_args="--disable=${disable_components} --flannel-backend=none  --kubelet-arg=root-dir=/ephemeral/kubelet --data-dir /ephemeral"
 
 # Process command-line options
 while getopts ":d:e:tagm:c:r:w:n:s:" opt; do
@@ -174,7 +174,7 @@ if [[ "$mode" == "init" ]]; then
     if [[ -n "$tls_san" ]]; then
         install_exec+=" --tls-san=${tls_san}"
     fi
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="$k3s_common_args $install_exec --data-dir /ephemeral" sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="$k3s_common_args $install_exec" sh -
     echo "K3s installation completed."
     token=$(cat /ephemeral/server/token)
     echo "K3s control-plane and worker node token: $token"

--- a/k3sAndProviderServices.sh
+++ b/k3sAndProviderServices.sh
@@ -176,7 +176,7 @@ if [[ "$mode" == "init" ]]; then
     fi
     curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="$k3s_common_args $install_exec --data-dir /ephemeral" sh -
     echo "K3s installation completed."
-    token=$(cat /var/lib/rancher/k3s/server/token)
+    token=$(cat /ephemeral/server/token)
     echo "K3s control-plane and worker node token: $token"
     echo "Installing Calico CNI..."
     curl -O https://raw.githubusercontent.com/projectcalico/calico/refs/tags/v3.28.2/manifests/calico.yaml

--- a/k3sAndProviderServices.sh
+++ b/k3sAndProviderServices.sh
@@ -12,11 +12,13 @@ mode="init"  # 'init' for initial setup, 'add' for adding control-plane nodes
 master_ip=""
 token=""
 internal_network=""
+kubelet_storage=""
+containerd_storage=""
 tls_san="" # Example: provider.h100.sdg.val.akash.pub
-k3s_common_args="--disable=${disable_components} --flannel-backend=none  --kubelet-arg=root-dir=/ephemeral/kubelet --data-dir /ephemeral"
+k3s_common_args="--disable=${disable_components} --flannel-backend=none"
 
 # Process command-line options
-while getopts ":d:e:tagm:c:r:w:n:s:" opt; do
+while getopts ":d:e:tagm:c:r:w:n:s:k:o:" opt; do
   case ${opt} in
     d )
       disable_components=$OPTARG
@@ -55,6 +57,12 @@ while getopts ":d:e:tagm:c:r:w:n:s:" opt; do
     \? )
       echo "Invalid option: $OPTARG" 1>&2
       exit 1
+      ;;
+    k )
+      kubelet_storage="--kubelet-arg=root-dir=$OPTARG"
+      ;;
+    o )
+      containerd_storage="--data-dir=$OPTARG"
       ;;
     : )
       echo "Invalid option: $OPTARG requires an argument" 1>&2
@@ -174,10 +182,24 @@ if [[ "$mode" == "init" ]]; then
     if [[ -n "$tls_san" ]]; then
         install_exec+=" --tls-san=${tls_san}"
     fi
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="$k3s_common_args $install_exec" sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="$k3s_common_args $install_exec $kubelet_storage $containerd_storage" sh -
     echo "K3s installation completed."
-    token=$(cat /ephemeral/server/token)
+
+    # display the server token
+    if [[ -n "$containerd_storage" ]]; then
+        # Extract the base path from containerd_storage
+        base_path=$(echo "$containerd_storage" | sed 's/--data-dir=//')
+        server_token_path="${base_path}/server/token"
+    fi
+
+    # Try to read the token, falling back to default location if needed
+    if [[ -f "$server_token_path" ]]; then
+        token=$(cat "$server_token_path")
+    else
+        token=$(cat "/var/lib/rancher/k3s/server/token")
+    fi
     echo "K3s control-plane and worker node token: $token"
+
     echo "Installing Calico CNI..."
     curl -O https://raw.githubusercontent.com/projectcalico/calico/refs/tags/v3.28.2/manifests/calico.yaml
     yq eval-all '(select(.kind == "DaemonSet" and .metadata.name == "calico-node").spec.template.spec.containers[] | select(.name == "calico-node").env) += {"name": "IP_AUTODETECTION_METHOD", "value": "kubernetes-internal-ip"}' -i calico.yaml
@@ -237,7 +259,7 @@ else
     fi
     # when K3S_URL is used, must add "server" when adding a new control-plane nodes to the cluster
     # it also must go first in the order, otherwise k3s.service will fail to start
-    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server ${k3s_common_args} ${install_exec}" K3S_URL="https://$master_ip:6443" K3S_TOKEN="$token" sh -
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server ${k3s_common_args} ${install_exec} $kubelet_storage $containerd_storage" K3S_URL="https://$master_ip:6443" K3S_TOKEN="$token" sh -
     echo "Control-plane node added to the cluster."
 fi
 

--- a/providerBuild.sh
+++ b/providerBuild.sh
@@ -254,8 +254,8 @@ if [ "$install_storage_support" = true ]; then
     echo "Rook-Ceph repository added."
 
     # Create the rook-ceph-operator.values.yaml file and append the kubelet directory location
-    touch /root/provider/rook-ceph-operator.values.yaml
-    echo "kubeletDirPath: /ephemeral/kubelet" >> /root/provider/rook-ceph-operator.values.yaml
+        echo "csi:" > /root/provider/rook-ceph-operator.values.yaml
+    echo "  kubeletDirPath: /data/kubelet" >> /root/provider/rook-ceph-operator.values.yaml
 
     # Install the Rook-Ceph Helm chart for the operator
     echo "Installing Rook-Ceph operator..."

--- a/providerBuild.sh
+++ b/providerBuild.sh
@@ -49,7 +49,6 @@ NODEFS_DIR=$(extract_path "$KUBELET_ARG" "$DEFAULT_KUBELET_DIR")
 
 # Debugging Output results
 echo "nodefs directory: $NODEFS_DIR"
-echo "imagefs directory: $IMAGEFS_DIR"
 
 # Function to fetch appVersion from Helm Chart
 fetch_app_version() {

--- a/providerBuild.sh
+++ b/providerBuild.sh
@@ -3,9 +3,9 @@
 # Provider Setup Script
 
 # Initialize variables with default values or empty
-ACCOUNT_ADDRESS="akash123456789"
-KEY_PASSWORD="blabla"
-DOMAIN="test.europlots.com"
+ACCOUNT_ADDRESS=""
+KEY_PASSWORD=""
+DOMAIN=""
 NODE=""  # Default to empty, will be set later based on chain_id or user input
 chain_id="akashnet-2"  # Default chain ID
 provider_version=""  # Will be fetched from Helm Chart

--- a/providerBuild.sh
+++ b/providerBuild.sh
@@ -259,13 +259,13 @@ if [ "$install_storage_support" = true ]; then
 
     # Install the Rook-Ceph Helm chart for the operator
     echo "Installing Rook-Ceph operator..."
-    helm install --create-namespace -n rook-ceph rook-ceph rook-release/rook-ceph --version 1.14.0 -f rook-ceph-operator.values.yml
+    helm install --create-namespace -n rook-ceph rook-ceph rook-release/rook-ceph --version 1.15.6 -f rook-ceph-operator.values.yml
     echo "Rook-Ceph operator installation completed."
 
     # Install the Rook-Ceph cluster
     echo "Installing Rook-Ceph cluster..."
     helm install --create-namespace -n rook-ceph rook-ceph-cluster \
-       --set operatorNamespace=rook-ceph rook-release/rook-ceph-cluster --version 1.14.0 \
+       --set operatorNamespace=rook-ceph rook-release/rook-ceph-cluster --version 1.15.6 \
        -f ~/provider/rook-ceph-cluster.values.yml
     echo "Rook-Ceph cluster installation completed."
 

--- a/providerBuild.sh
+++ b/providerBuild.sh
@@ -253,9 +253,13 @@ if [ "$install_storage_support" = true ]; then
     helm repo update
     echo "Rook-Ceph repository added."
 
+    # Create the rook-ceph-operator.values.yaml file and append the kubelet directory location
+    touch /root/provider/rook-ceph-operator.values.yaml
+    echo "kubeletDirPath: /ephemeral/kubelet" >> /root/provider/rook-ceph-operator.values.yaml
+
     # Install the Rook-Ceph Helm chart for the operator
     echo "Installing Rook-Ceph operator..."
-    helm install --create-namespace -n rook-ceph rook-ceph rook-release/rook-ceph --version 1.14.0
+    helm install --create-namespace -n rook-ceph rook-ceph rook-release/rook-ceph --version 1.14.0 -f rook-ceph-operator.values.yml
     echo "Rook-Ceph operator installation completed."
 
     # Install the Rook-Ceph cluster

--- a/workerNode.sh
+++ b/workerNode.sh
@@ -10,10 +10,11 @@ master_ip=""
 token=""
 install_gpu_drivers=false
 install_storage_support=false
-k3s_common_args="--kubelet-arg=root-dir=/ephemeral/kubelet --data-dir /ephemeral"
+kubelet_storage=""
+containerd_storage=""
 
 # Process command-line options
-while getopts ":m:t:gs" opt; do
+while getopts ":m:t:gs:k:o:" opt; do
   case ${opt} in
     m )
       master_ip=$OPTARG
@@ -26,6 +27,12 @@ while getopts ":m:t:gs" opt; do
       ;;
     s )
       install_storage_support=true
+      ;;
+    k )
+      kubelet_storage="--kubelet-arg=root-dir=$OPTARG"
+      ;;
+    o )
+      containerd_storage="--data-dir=$OPTARG"
       ;;
     \? )
       echo "Invalid option: $OPTARG" 1>&2
@@ -47,7 +54,7 @@ fi
 
 # Install K3s worker node
 echo "Starting K3s installation on worker node..."
-curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="$k3s_common_args" sh -
+curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="$kubelet_storage $containerd_storage" sh -
 
 # Check if K3s agent is running
 echo "Verifying K3s installation on worker node..."

--- a/workerNode.sh
+++ b/workerNode.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Example use:
-#./worker.sh -m 10.128.0.8 -t K10cef5da8867a6d3d2acc25aa817c7c06f86a638ee7ad4c0668c248c23167c1140::server:da3e13b2aafc1983789be9841b7e5e83 -g -s
+#./worker.sh -m 10.128.0.8 -t K10cef5da8867a6d3d2acc25aa817c7c06f86a638ee7ad4c0668c248c23167c1140::server:da3e13b2aafc1983789be9841b7e5e83 -g -s  -o /data/containerd -k /data/kubelet
 
 # Worker Script
 

--- a/workerNode.sh
+++ b/workerNode.sh
@@ -47,7 +47,7 @@ fi
 
 # Install K3s worker node
 echo "Starting K3s installation on worker node..."
-curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="$k3s_common_args" --data-dir /ephemeral"  sh -
+curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="$k3s_common_args" sh -
 
 # Check if K3s agent is running
 echo "Verifying K3s installation on worker node..."

--- a/workerNode.sh
+++ b/workerNode.sh
@@ -10,6 +10,7 @@ master_ip=""
 token=""
 install_gpu_drivers=false
 install_storage_support=false
+k3s_common_args="--kubelet-arg=root-dir=/ephemeral/kubelet --data-dir /ephemeral"
 
 # Process command-line options
 while getopts ":m:t:gs" opt; do
@@ -46,7 +47,7 @@ fi
 
 # Install K3s worker node
 echo "Starting K3s installation on worker node..."
-curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="--data-dir /ephemeral"  sh -
+curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="$k3s_common_args" --data-dir /ephemeral"  sh -
 
 # Check if K3s agent is running
 echo "Verifying K3s installation on worker node..."

--- a/workerNode.sh
+++ b/workerNode.sh
@@ -46,7 +46,7 @@ fi
 
 # Install K3s worker node
 echo "Starting K3s installation on worker node..."
-curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token sh -
+curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="--data-dir /ephemeral"  sh -
 
 # Check if K3s agent is running
 echo "Verifying K3s installation on worker node..."

--- a/workerNode.sh
+++ b/workerNode.sh
@@ -12,9 +12,10 @@ install_gpu_drivers=false
 install_storage_support=false
 kubelet_storage=""
 containerd_storage=""
+INSTALL_K3S_EXEC=""
 
 # Process command-line options
-while getopts ":m:t:gs:k:o:" opt; do
+while getopts ":m:t:gsk:o:" opt; do
   case ${opt} in
     m )
       master_ip=$OPTARG
@@ -52,8 +53,13 @@ if [ -z "$master_ip" ] || [ -z "$token" ]; then
     exit 1
 fi
 
+# debugging OPTARG
+echo "Debug: kubelet_storage = $kubelet_storage"
+echo "Debug: containerd_storage = $containerd_storage"
+
 # Install K3s worker node
 echo "Starting K3s installation on worker node..."
+echo "INSTALL_K3S_EXEC value: agent ${kubelet_storage} ${containerd_storage}"
 curl -sfL https://get.k3s.io | K3S_URL=https://$master_ip:6443 K3S_TOKEN=$token INSTALL_K3S_EXEC="$kubelet_storage $containerd_storage" sh -
 
 # Check if K3s agent is running


### PR DESCRIPTION
If this PR is accepted, all providers built with these scripts will have their respective imagefs/nodefs directory located in /ephemeral, regardless if a separate storage is being used for this purpose or not. The original /var/lib/containerd and /var/lib/kubelet directories will no longer be used.

If a new provider has dedicated imagefs/nodefs storage, as most high-end providers do, make sure the storage is mounted on /ephemeral in r/w mode.